### PR TITLE
Onnx transformers: Quantize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![onnx_transformers](https://github.com/patil-suraj/onnx_transformers/blob/master/data/social_preview.jpeg?raw=True)
 
-Accelerated NLP pipelines for fast inference 🚀 on CPU. Built with 🤗Transformers and ONNX runtime.
+Accelerated NLP pipelines for fast inference 🚀 on CPU. Built with 🤗Transformers and ONNX runtime. +Plus quantize option 😊
 
 ## Installation:
 
@@ -41,7 +41,16 @@ from onnx_transformers import pipeline
 {'answer': 'highly performant single inference engine for multiple platforms and hardware', 'end': 94, 'score': 0.751201868057251, 'start': 18}
 ```
 
+```python
+from onnx_transformers import pipeline
+
+>>> nlp = pipeline("ner", model="mys/electra-base-turkish-cased-ner", onnx=True, quantized=True, grouped_entities=True)
+>>> nlp("adana kebap ülkemizin önemli lezzetlerinden biridir.")
+[{'entity_group': 'B-food', 'score': 0.869149774312973, 'word': 'adana kebap'}]
+```
+
 Set `onnx` to `False` for standard torch inference.
+Set `quantized` to `True` for quantize with Onnx. ( set `onnx` to True)
 
 You can create `Pipeline` objects for the following down-stream tasks:
 

--- a/onnx_transformers/pipelines.py
+++ b/onnx_transformers/pipelines.py
@@ -1741,10 +1741,10 @@ def pipeline(
     modelcard = None
     # Try to infer modelcard from model or config name (if provided as str)
     # TODO: Comment modelcard (below 4 lines) if working with local models.
-    # if isinstance(model, str):
-    #     modelcard = model
-    # elif isinstance(config, str):
-    #     modelcard = config
+    if isinstance(model, str):
+        modelcard = model
+    elif isinstance(config, str):
+        modelcard = config
 
     # Instantiate tokenizer if needed
     if isinstance(tokenizer, (str, tuple)):

--- a/tests/test_pipelines_onnx.py
+++ b/tests/test_pipelines_onnx.py
@@ -23,6 +23,9 @@ class OnnxExportTestCase(unittest.TestCase):
 
     def test_ner_forward(self):
         self._test_pipeline_forward("ner", "My name is Bert")
+    
+    def test_ner_quantized_forward(self):
+        self._test_pipeline_forward("ner", "My name is Bert", quantized=True)
 
     def test_question_answering_forward(self):
         self._test_pipeline_forward(
@@ -45,10 +48,10 @@ class OnnxExportTestCase(unittest.TestCase):
         except Exception as e:
             self.fail(e)
 
-    def _test_pipeline_forward(self, task, example):
+    def _test_pipeline_forward(self, task, example, quantized:bool = False):
         try:
             # test onnx forward
-            nlp = pipeline(task, onnx=True)
+            nlp = pipeline(task, onnx=True, quantized=quantized)
             nlp(example)
 
             # test torch forward


### PR DESCRIPTION
I've made changes as we talked in [pr](https://github.com/patil-suraj/onnx_transformers/pull/5).

I added option `local_model` to pipeline. It ignores `modelcard` to load local models that without having modelcard.

I kept framework as torch. In some cases like loading local models i have got error that `InvalidArgument: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Unexpected input data type.`. We can leave it like this to stay safe.